### PR TITLE
feat(packaging): Add scripts and configurations for building various package formats (deb, rpm, apk, snap, pacman, osxpkg)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -184,31 +184,31 @@ jobs:
 
 
           if [ -n "$AMDEB" ]; then
-            cp "$AMDEB" "agent_${VERSION}_any.deb"
+            cp "$AMDEB" "makim_${VERSION}_any.deb"
           else
             echo "Warning: No amd64 DEB package found"
           fi
 
           if [ -n "$AMRPM" ]; then
-            cp "$AMRPM" "agent-${VERSION}-1.noarch.rpm"
+            cp "$AMRPM" "makim-${VERSION}-1.noarch.rpm"
           else
             echo "Warning: No x86_64 RPM package found"
           fi
 
           if [ -n "$AMAPK" ]; then
-            cp "$AMAPK" "agent-${VERSION}-noarch.apk"
+            cp "$AMAPK" "makim-${VERSION}-noarch.apk"
           else
             echo "Warning: No APK package found"
           fi
 
           if [ -n "$AMPKG" ]; then
-            cp "$AMPKG" "agent-${VERSION}-noarch.pkg.tar.xz"
+            cp "$AMPKG" "makim-${VERSION}-noarch.pkg.tar.xz"
           else
             echo "Warning: No pacman package found"
           fi
 
           if [ -n "$AMSNAP" ]; then
-            cp "$AMSNAP" "agent_${VERSION}_any.snap"
+            cp "$AMSNAP" "makim_${VERSION}_any.snap"
           else
             echo "Warning: No snap package found"
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+
+# Add permissions needed for creating releases
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   release:
@@ -61,3 +67,157 @@ jobs:
       - name: Setup tmate session
         if: "${{ failure() && (contains(github.event.pull_request.labels.*.name, 'ci:enable-debugging')) }}"
         uses: mxschmitt/action-tmate@v3
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            goarch: amd64
+            deb_arch: amd64
+            rpm_arch: x86_64
+          - arch: arm64
+            goarch: arm64
+            deb_arch: arm64
+            rpm_arch: aarch64
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-version: latest
+          environment-file: conda/release.yaml
+          channels: conda-forge,nodefaults
+          activate-environment: makim
+          auto-update-conda: true
+          conda-solver: libmamba
+          python-version: "3.11"
+
+      - name: Install deps
+        run: |
+          poetry config virtualenvs.create false
+          poetry install
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.0"
+
+      - name: Install FPM
+        run: gem install fpm
+
+      - name: APT Install rpm and snap dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm snapd
+
+      - name: Make scripts executable
+        run: chmod +x scripts/postinstall.sh
+
+      - name: Package DEB for ${{ matrix.arch }}
+        run: |
+          makim --verbose packaging.build_deb
+
+      - name: Package RPM for ${{ matrix.arch }}
+        run: |
+          makim --verbose packaging.build_rpm
+
+      - name: Package Snap for ${{ matrix.arch }}
+        run: |
+          makim --verbose packaging.build_snap
+
+      - name: Package apk for ${{ matrix.arch }}
+        run: |
+          makim --verbose packaging.build_apk
+
+      - name: Package pacman for ${{ matrix.arch }}
+        run: |
+          makim --verbose packaging.build_pacman
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages-${{ matrix.arch }}
+          path: |
+            *.deb
+            *.rpm
+            *.snap
+            *.apk
+            *.pkg.tar.xz
+
+  package-release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get the version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: packages
+
+      - name: Display structure of downloaded files
+        run: ls -R packages
+
+      - name: Flatten directory structure
+        run: |
+          mkdir -p release_files
+          find packages -type f -name "*.deb" -o -name "*.rpm" -o -name "*.snap" -o -name "*.apk" -o -name "*.pkg.tar.xz" | xargs -I {} cp {} release_files/
+
+      - name: Create "any" and "noarch" packages
+        run: |
+          # For demonstration, create copies of the amd64 packages for architecture-independent packages
+          cd release_files
+          ls -la
+          # Find the correct files dynamically instead of hardcoding names
+          AMDEB=$(find . -name "*amd64.deb" | head -1)
+          AMRPM=$(find . -name "*x86_64.rpm" | head -1)
+          AMAPK=$(find . -name "*.apk" | head -1)
+          AMPKG=$(find . -name "*.pkg.tar.xz" | head -1)
+          AMSNAP=$(find . -name "*.snap" | head -1)
+
+
+          if [ -n "$AMDEB" ]; then
+            cp "$AMDEB" "agent_${VERSION}_any.deb"
+          else
+            echo "Warning: No amd64 DEB package found"
+          fi
+
+          if [ -n "$AMRPM" ]; then
+            cp "$AMRPM" "agent-${VERSION}-1.noarch.rpm"
+          else
+            echo "Warning: No x86_64 RPM package found"
+          fi
+
+          if [ -n "$AMAPK" ]; then
+            cp "$AMAPK" "agent-${VERSION}-noarch.apk"
+          else
+            echo "Warning: No APK package found"
+          fi
+
+          if [ -n "$AMPKG" ]; then
+            cp "$AMPKG" "agent-${VERSION}-noarch.pkg.tar.xz"
+          else
+            echo "Warning: No pacman package found"
+          fi
+
+          if [ -n "$AMSNAP" ]; then
+            cp "$AMSNAP" "agent_${VERSION}_any.snap"
+          else
+            echo "Warning: No snap package found"
+          fi
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: release_files/*
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # log tests files
 tests/smoke/logs
+
+# Ignore fpm packaged files
+makim_*
+makim-*

--- a/.makim.yaml
+++ b/.makim.yaml
@@ -626,3 +626,31 @@ groups:
           # it requires the password manually
           ssh-keygen -R "[localhost]:2222" || true
           ssh -o StrictHostKeyChecking=no testuser@localhost -p 2222 'pwd'
+
+  packaging:
+    help: Tasks for packaging via fpm
+    tasks:
+      build_deb:
+        help: Build a deb package
+        dir: .
+        run: bash ./packaging/scripts/deb.sh
+      build_binary:
+        help: Build a binary package
+        dir: .
+        run: poetry build && pyinstaller --onefile -n makim-linux-x86-64 --add-data 'src/makim/schema.json:.' src/makim/__main__.py
+      build_rpm:
+        help: Build a rpm package
+        dir: .
+        run: bash ./packaging/scripts/rpm.sh
+      build_apk:
+        help: Build a apk package
+        dir: .
+        run: bash ./packaging/scripts/apk.sh
+      build_snap:
+        help: Build a snap package
+        dir: .
+        run: bash ./packaging/scripts/snap.sh
+      build_pacman:
+        help: Build a pacman package
+        dir: .
+        run: bash ./packaging/scripts/pacman.sh

--- a/packaging/makim.service
+++ b/packaging/makim.service
@@ -1,5 +1,5 @@
 [unit]
-Description=
+Description=A tool that helps organize and simplify helper commands using YAML configuration
 After=network.target
 
 [Service]

--- a/packaging/makim.service
+++ b/packaging/makim.service
@@ -1,0 +1,11 @@
+[unit]
+Description=
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/makim
+Restart=on-failure
+User=root
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/scripts/apk.sh
+++ b/packaging/scripts/apk.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Dynamically fetch the version from pyproject.toml
+VERSION=$(awk -F'"' '/version = /{print $2}' ./pyproject.toml | head -1)
+MAKIM_BIN=$(ls ./dist/makim-linux-*)
+
+echo "Building Debian package for Makim version: $VERSION"
+echo "Using makim binary: $MAKIM_BIN"
+
+# Build the Debian package using fpm
+if [ -z "$VERSION" ]; then
+  echo "Error: Version not found in pyproject.toml"
+  exit 1
+fi
+if [ -z "$MAKIM_BIN" ]; then
+  echo "Error: makim binary not found in dist directory"
+  exit 1
+fi
+if ! command -v fpm &> /dev/null; then
+  echo "Error: fpm is not installed. Please install it to proceed."
+  exit 1
+fi
+if [ ! -f ./packaging/scripts/postinstall.sh ]; then
+  echo "Error: postinstall script not found."
+  exit 1
+fi
+if [ ! -f ./packaging/makim.service ]; then
+  echo "Error: makim service file not found."
+  exit 1
+fi
+if [ ! -f ./packaging/dependencies.txt ]; then
+  echo "Error: dependencies.txt file not found."
+  exit 1
+fi
+if [ ! -d ./dist ]; then
+  echo "Error: dist directory not found."
+  exit 1
+fi
+if [ ! -f ./pyproject.toml ]; then
+  echo "Error: pyproject.toml not found."
+  exit 1
+fi
+if [ ! -d ./packaging/scripts ]; then
+  echo "Error: packaging/scripts directory not found."
+  exit 1
+fi
+
+
+# Create the Debian package
+fpm -s dir -t apk -n makim -v $VERSION \
+ --architecture amd64 \
+ --description "Makim" \
+ --maintainer "Ivan Ogaswara <ivan.ogasawara@gmail.com>" \
+ --depends "apk" \
+ --after-install packaging/scripts/postinstall.sh \
+ --deb-pre-depends "apk" \
+ --allows-untrusted \ # fpm suggests this option for apk packages
+ $MAKIM_BIN=/usr/local/bin/makim \
+ ./packaging/makim.service=/lib/systemd/system/makim.service \
+ ./packaging/dependencies.txt=/usr/share/agent/dependencies.txt

--- a/packaging/scripts/deb.sh
+++ b/packaging/scripts/deb.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Dynamically fetch the version from pyproject.toml
+VERSION=$(awk -F'"' '/version = /{print $2}' ./pyproject.toml | head -1)
+MAKIM_BIN=$(ls ./dist/makim-linux-*)
+
+echo "Building Debian package for Makim version: $VERSION"
+echo "Using makim binary: $MAKIM_BIN"
+
+# Build the Debian package using fpm
+if [ -z "$VERSION" ]; then
+  echo "Error: Version not found in pyproject.toml"
+  exit 1
+fi
+if [ -z "$MAKIM_BIN" ]; then
+  echo "Error: makim binary not found in dist directory"
+  exit 1
+fi
+if ! command -v fpm &> /dev/null; then
+  echo "Error: fpm is not installed. Please install it to proceed."
+  exit 1
+fi
+if [ ! -f ./packaging/scripts/postinstall.sh ]; then
+  echo "Error: postinstall script not found."
+  exit 1
+fi
+if [ ! -f ./packaging/makim.service ]; then
+  echo "Error: makim service file not found."
+  exit 1
+fi
+if [ ! -f ./packaging/dependencies.txt ]; then
+  echo "Error: dependencies.txt file not found."
+  exit 1
+fi
+if [ ! -d ./dist ]; then
+  echo "Error: dist directory not found."
+  exit 1
+fi
+if [ ! -f ./pyproject.toml ]; then
+  echo "Error: pyproject.toml not found."
+  exit 1
+fi
+if [ ! -d ./packaging/scripts ]; then
+  echo "Error: packaging/scripts directory not found."
+  exit 1
+fi
+
+
+# Create the Debian package
+fpm -s dir -t deb -n makim -v $VERSION \
+ --architecture amd64 \
+ --description "Makim" \
+ --maintainer "Ivan Ogaswara <ivan.ogasawara@gmail.com>" \
+ --depends "apt" \
+ --deb-compression "xz" \
+ --after-install packaging/scripts/postinstall.sh \
+ --deb-pre-depends "apt" \
+ $MAKIM_BIN=/usr/local/bin/makim \
+ ./packaging/makim.service=/lib/systemd/system/makim.service \
+ ./packaging/dependencies.txt=/usr/share/agent/dependencies.txt

--- a/packaging/scripts/osxpkg.sh
+++ b/packaging/scripts/osxpkg.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Dynamically fetch the version from pyproject.toml
+VERSION=$(awk -F'"' '/version = /{print $2}' ./pyproject.toml | head -1)
+MAKIM_BIN=$(ls ./dist/makim-linux-*)
+
+echo "Building Debian package for Makim version: $VERSION"
+echo "Using makim binary: $MAKIM_BIN"
+
+# Build the Debian package using fpm
+if [ -z "$VERSION" ]; then
+  echo "Error: Version not found in pyproject.toml"
+  exit 1
+fi
+if [ -z "$MAKIM_BIN" ]; then
+  echo "Error: makim binary not found in dist directory"
+  exit 1
+fi
+if ! command -v fpm &> /dev/null; then
+  echo "Error: fpm is not installed. Please install it to proceed."
+  exit 1
+fi
+if [ ! -f ./packaging/scripts/postinstall.sh ]; then
+  echo "Error: postinstall script not found."
+  exit 1
+fi
+if [ ! -f ./packaging/makim.service ]; then
+  echo "Error: makim service file not found."
+  exit 1
+fi
+if [ ! -f ./packaging/dependencies.txt ]; then
+  echo "Error: dependencies.txt file not found."
+  exit 1
+fi
+if [ ! -d ./dist ]; then
+  echo "Error: dist directory not found."
+  exit 1
+fi
+if [ ! -f ./pyproject.toml ]; then
+  echo "Error: pyproject.toml not found."
+  exit 1
+fi
+if [ ! -d ./packaging/scripts ]; then
+  echo "Error: packaging/scripts directory not found."
+  exit 1
+fi
+
+
+# Create the OSX package
+fpm -s dir -t osxpkg -n makim -v $VERSION \
+ --architecture amd64 \
+ --description "Makim" \
+ --maintainer "Ivan Ogaswara <ivan.ogasawara@gmail.com>" \
+ --depends "osxpkg" \
+ --after-install packaging/scripts/postinstall.sh \
+ $MAKIM_BIN=/usr/local/bin/makim \
+ ./packaging/makim.service=/lib/systemd/system/makim.service \
+ ./packaging/dependencies.txt=/usr/share/agent/dependencies.txt

--- a/packaging/scripts/pacman.sh
+++ b/packaging/scripts/pacman.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Dynamically fetch the version from pyproject.toml
+VERSION=$(awk -F'"' '/version = /{print $2}' ./pyproject.toml | head -1)
+MAKIM_BIN=$(ls ./dist/makim-linux-*)
+
+echo "Building Debian package for Makim version: $VERSION"
+echo "Using makim binary: $MAKIM_BIN"
+
+# Build the Debian package using fpm
+if [ -z "$VERSION" ]; then
+  echo "Error: Version not found in pyproject.toml"
+  exit 1
+fi
+if [ -z "$MAKIM_BIN" ]; then
+  echo "Error: makim binary not found in dist directory"
+  exit 1
+fi
+if ! command -v fpm &> /dev/null; then
+  echo "Error: fpm is not installed. Please install it to proceed."
+  exit 1
+fi
+if [ ! -f ./packaging/scripts/postinstall.sh ]; then
+  echo "Error: postinstall script not found."
+  exit 1
+fi
+if [ ! -f ./packaging/makim.service ]; then
+  echo "Error: makim service file not found."
+  exit 1
+fi
+if [ ! -f ./packaging/dependencies.txt ]; then
+  echo "Error: dependencies.txt file not found."
+  exit 1
+fi
+if [ ! -d ./dist ]; then
+  echo "Error: dist directory not found."
+  exit 1
+fi
+if [ ! -f ./pyproject.toml ]; then
+  echo "Error: pyproject.toml not found."
+  exit 1
+fi
+if [ ! -d ./packaging/scripts ]; then
+  echo "Error: packaging/scripts directory not found."
+  exit 1
+fi
+
+
+# Create the Pacman package
+fpm -s dir -t pacman -n makim -v $VERSION \
+ --architecture amd64 \
+ --description "Makim" \
+ --maintainer "Ivan Ogaswara <ivan.ogasawara@gmail.com>" \
+ --depends "pacman" \
+ --after-install packaging/scripts/postinstall.sh \
+ --deb-pre-depends "pacman" \
+ --pacman-compression "xz" \
+ $MAKIM_BIN=/usr/local/bin/makim \
+ ./packaging/makim.service=/lib/systemd/system/makim.service \
+ ./packaging/dependencies.txt=/usr/share/agent/dependencies.txt

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,0 +1,7 @@
+chmod +x /usr/local/bin/makim
+
+systemctl daemon-reload
+# Enable the makim service to start on boot
+systemctl enable makim.service
+# Start the makim service
+systemctl start makim.service

--- a/packaging/scripts/rpm.sh
+++ b/packaging/scripts/rpm.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Dynamically fetch the version from pyproject.toml
+VERSION=$(awk -F'"' '/version = /{print $2}' ./pyproject.toml | head -1)
+MAKIM_BIN=$(ls ./dist/makim-linux-*)
+
+echo "Building Debian package for Makim version: $VERSION"
+echo "Using makim binary: $MAKIM_BIN"
+
+# Build the Debian package using fpm
+if [ -z "$VERSION" ]; then
+  echo "Error: Version not found in pyproject.toml"
+  exit 1
+fi
+if [ -z "$MAKIM_BIN" ]; then
+  echo "Error: makim binary not found in dist directory"
+  exit 1
+fi
+if ! command -v fpm &> /dev/null; then
+  echo "Error: fpm is not installed. Please install it to proceed."
+  exit 1
+fi
+if [ ! -f ./packaging/scripts/postinstall.sh ]; then
+  echo "Error: postinstall script not found."
+  exit 1
+fi
+if [ ! -f ./packaging/makim.service ]; then
+  echo "Error: makim service file not found."
+  exit 1
+fi
+if [ ! -f ./packaging/dependencies.txt ]; then
+  echo "Error: dependencies.txt file not found."
+  exit 1
+fi
+if [ ! -d ./dist ]; then
+  echo "Error: dist directory not found."
+  exit 1
+fi
+if [ ! -f ./pyproject.toml ]; then
+  echo "Error: pyproject.toml not found."
+  exit 1
+fi
+if [ ! -d ./packaging/scripts ]; then
+  echo "Error: packaging/scripts directory not found."
+  exit 1
+fi
+
+
+# Create the Debian package
+fpm -s dir -t rpm -n makim -v $VERSION \
+ --architecture amd64 \
+ --description "Makim" \
+ --maintainer "Ivan Ogaswara <ivan.ogasawara@gmail.com>" \
+ --depends "rpm" \
+ --after-install packaging/scripts/postinstall.sh \
+ --deb-pre-depends "rpm" \
+ --rpm-compression-level 9 \
+ --rpm-compression "xz" \
+ $MAKIM_BIN=/usr/local/bin/makim \
+ ./packaging/makim.service=/lib/systemd/system/makim.service \
+ ./packaging/dependencies.txt=/usr/share/agent/dependencies.txt

--- a/packaging/scripts/snap.sh
+++ b/packaging/scripts/snap.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Dynamically fetch the version from pyproject.toml
+VERSION=$(awk -F'"' '/version = /{print $2}' ./pyproject.toml | head -1)
+MAKIM_BIN=$(ls ./dist/makim-linux-*)
+
+echo "Building Debian package for Makim version: $VERSION"
+echo "Using makim binary: $MAKIM_BIN"
+
+# Build the Debian package using fpm
+if [ -z "$VERSION" ]; then
+  echo "Error: Version not found in pyproject.toml"
+  exit 1
+fi
+if [ -z "$MAKIM_BIN" ]; then
+  echo "Error: makim binary not found in dist directory"
+  exit 1
+fi
+if ! command -v fpm &> /dev/null; then
+  echo "Error: fpm is not installed. Please install it to proceed."
+  exit 1
+fi
+if [ ! -f ./packaging/scripts/postinstall.sh ]; then
+  echo "Error: postinstall script not found."
+  exit 1
+fi
+if [ ! -f ./packaging/makim.service ]; then
+  echo "Error: makim service file not found."
+  exit 1
+fi
+if [ ! -f ./packaging/dependencies.txt ]; then
+  echo "Error: dependencies.txt file not found."
+  exit 1
+fi
+if [ ! -d ./dist ]; then
+  echo "Error: dist directory not found."
+  exit 1
+fi
+if [ ! -f ./pyproject.toml ]; then
+  echo "Error: pyproject.toml not found."
+  exit 1
+fi
+if [ ! -d ./packaging/scripts ]; then
+  echo "Error: packaging/scripts directory not found."
+  exit 1
+fi
+
+
+# Create the snap package
+fpm -s dir -t snap -n makim -v $VERSION \
+ --architecture amd64 \
+ --description "Makim" \
+ --maintainer "Ivan Ogaswara <ivan.ogasawara@gmail.com>" \
+ --depends "snap" \
+ --after-install packaging/scripts/postinstall.sh \
+ --deb-pre-depends "snap" \
+ $MAKIM_BIN=/usr/local/bin/makim \
+ ./packaging/makim.service=/lib/systemd/system/makim.service \
+ ./packaging/dependencies.txt=/usr/share/agent/dependencies.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "makim"
 version = "1.25.0"  # semantic-release
-description = "Simplify the usage of containers"
+description = "A tool that helps organize and simplify helper commands using YAML configuration"
 authors = [
   {name = "Ivan Ogasawara", email = "ivan.ogasawara@gmail.com"}
 ]


### PR DESCRIPTION
## Pull Request description

This pull request introduces a comprehensive workflow for building, packaging, and releasing the `makim` project across multiple formats (DEB, RPM, APK, Snap, Pacman, OSX). Key changes include updates to the GitHub Actions workflow, packaging scripts, and configuration files to support automated packaging and release processes.



## How to test these changes

<!-- Example:

* run `$ abc -p 1234`
* open the web browser with url localhost:1234
* ...
-->

- `...`

<!-- Modify the options to suit your project. -->

## Pull Request checklists

This PR is a:

- [ ] bug-fix
- [x] new feature
- [ ] maintenance

About this PR:

- [x] Added a new `build` job with matrix builds for multiple architectures (amd64, arm64) and packaging steps for DEB, RPM, APK, Snap, Pacman, and more. Also added permissions for creating releases and artifact uploads. 
- [x] Updated the project description to better reflect the functionality of `makim`.
- [x]  Added a systemd service file for `makim` to enable automatic service management.
- [x] Added a post-install script to set up permissions, reload systemd, enable the `makim` service, and start it after installation.
- [x] Added scripts for building packages using `fpm`, dynamically fetching version information, and validating required files and dependencies. Each script specifies packaging formats and configurations

Author's checklist:

- [x] I have reviewed the changes and it contains no misspelling.
- [ ] The code is well commented, especially in the parts that contain more
      complexity.
- [ ] New and old tests passed locally.

## Additional information

Currently tested the .deb package on pop-os (ubuntu 22.04)

![image](https://github.com/user-attachments/assets/99d92afa-3735-46ad-b0b7-cb6817719598)
![image](https://github.com/user-attachments/assets/644c981e-5910-4542-b615-7659088cb61d)

